### PR TITLE
Fixed the bug that -initWithMetadataObjectTypes: method is not configured by metadata object type.

### DIFF
--- a/QRCodeReaderViewController/QRCodeReaderViewController.m
+++ b/QRCodeReaderViewController/QRCodeReaderViewController.m
@@ -59,7 +59,7 @@
 
 - (id)initWithMetadataObjectTypes:(NSArray *)metadataObjectTypes
 {
-  return [self initWithCancelButtonTitle:nil metadataObjectTypes:@[AVMetadataObjectTypeQRCode]];
+  return [self initWithCancelButtonTitle:nil metadataObjectTypes:metadataObjectTypes];
 }
 
 - (id)initWithCancelButtonTitle:(NSString *)cancelTitle metadataObjectTypes:(NSArray *)metadataObjectTypes


### PR DESCRIPTION
I fixed the bug.
Please check my pull request.