### PR TITLE
Add nullability to the completion block

### DIFF
--- a/QRCodeReaderViewController/QRCodeReaderViewController.h
+++ b/QRCodeReaderViewController/QRCodeReaderViewController.h
@@ -173,7 +173,7 @@
  * is nil.
  * @since 1.0.1
  */
-- (void)setCompletionWithBlock:(void (^) (NSString *resultAsString))completionBlock;
+- (void)setCompletionWithBlock:(nullable void (^) (NSString * __nullable resultAsString))completionBlock;
 
 #pragma mark - Managing the Reader
 /** @name Managing the Reader */

--- a/QRCodeReaderViewController/QRCodeReaderViewController.m
+++ b/QRCodeReaderViewController/QRCodeReaderViewController.m
@@ -35,7 +35,7 @@
 @property (strong, nonatomic) QRCodeReader         *codeReader;
 @property (assign, nonatomic) BOOL                 startScanningAtLoad;
 
-@property (copy, nonatomic) void (^completionBlock) (NSString *);
+@property (copy, nonatomic) void (^completionBlock) (NSString * __nullable);
 
 @end
 


### PR DESCRIPTION
Hi.
I've been using this library in a Swift project, and when using the completion block, if the user cancels the scan result in a runtime exception due to a force unwrap of a nil Optional (the one passed in the completion block). 
This PR adds the new `nullable` modifier to the block's parameter, so that the Swift signature is:
```swift
reader.setCompletionWithBlock(completionBlock: (String? -> Void)?)
```
instead of 
```swift
reader.setCompletionWithBlock(completionBlock: (String! -> Void)?)
``` 