### PR TITLE
typeof isn't recognized in non gnu C Language Dialect modes

### DIFF
--- a/QRCodeReaderViewController/QRCodeReaderViewController.m
+++ b/QRCodeReaderViewController/QRCodeReaderViewController.m
@@ -104,7 +104,7 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
 
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
 
     [codeReader setCompletionWithBlock:^(NSString *resultAsString) {
       if (weakSelf.completionBlock != nil) {


### PR DESCRIPTION
`typeof` fails to compile when C Language Dialect is set to for example c11. `__typeof__` is safe in clang.
[http://clang.llvm.org/docs/UsersManual.html#differences-between-various-standard-modes](http://clang.llvm.org/docs/UsersManual.html#differences-between-various-standard-modes)