### PR TITLE
Only sets AVMetadataObjectTypes that are available

### DIFF
--- a/QRCodeReaderViewController/QRCodeReader.m
+++ b/QRCodeReaderViewController/QRCodeReader.m
@@ -101,7 +101,10 @@
   }
 
   [_metadataOutput setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
-  [_metadataOutput setMetadataObjectTypes:_metadataObjectTypes];
+  NSMutableSet *available = [NSMutableSet setWithArray:[_metadataOutput availableMetadataObjectTypes]];
+  NSSet *desired = [NSSet setWithArray:_metadataObjectTypes];
+  [available intersectSet:desired];
+  [_metadataOutput setMetadataObjectTypes:available.allObjects];
   [_previewLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
 }
 


### PR DESCRIPTION
Resolves a crash when passing types that aren’t available.